### PR TITLE
Fix undefined variable usage in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,6 +59,7 @@ def generate_data():
     # ——————————————————————————
     print(f"\n🔎 Variables en el Thing {THING_ID}:")
     props_api = iot.PropertiesV2Api(client)
+    props = []
     try:
         props = props_api.properties_v2_list(id=THING_ID, show_deleted=False)
         if not props:


### PR DESCRIPTION
## Summary
- ensure `props` is defined when Arduino API call fails

## Testing
- `python -m py_compile main.py Querytest.py Querytest2.py onlyArduino.py`